### PR TITLE
Implement profile-based restore and harden rollback flows

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -14,8 +14,14 @@ winconf.ps1 [-DryRun] [-Verbose] [-Rollback] [-Module <name>]
 | ----------- | ------ | -------------------------------------------------------- |
 | `-DryRun`   | switch | Print what would change; make no writes                  |
 | `-Verbose`  | switch | Print each registry/service operation to console         |
-| `-Rollback` | switch | Restore all values from snapshot, then exit              |
+| `-Rollback` | switch | Restore values from snapshot history, then exit          |
 | `-Module`   | string | Run only the named module (e.g. `Power`, `ScreenLock`)   |
+
+Script interface policy:
+
+- `-Rollback` is the historical rollback mode backed by snapshot data.
+- The product may introduce a future profile-based restore mode that restores to predefined target configurations rather than to recorded historical state.
+- Historical rollback and profile-based restore are distinct behaviors and must not be conflated.
 
 ---
 
@@ -78,6 +84,16 @@ Restore-Snapshot
 - Snapshot file: `C:\ProgramData\WinConf\snapshot.json`
 - Schema per entry: `{ module, key, value, type, timestamp }`
 - `Restore-Snapshot` replays entries in reverse order
+- Snapshot is the historical-state restore mechanism.
+- Snapshot is not the same thing as a predefined restore profile.
+
+### 2.5 Restore Governance
+
+- WinConf must support two restore models:
+  - snapshot-based rollback to recorded historical state
+  - profile-based restore to predefined target state
+- Shared governance must make this distinction explicit in implementation structure, tests, and user-facing behavior.
+- Profile-based restore should reuse shared metadata where feasible so registry, service, and command-driven modules can express reverse behavior through a common abstraction.
 
 ---
 
@@ -241,3 +257,13 @@ On drift detection: write `WARN` log entry, re-invoke the affected `Set-RegValue
 - Service not found -> log `WARN`, skip (do not throw)
 - `powercfg` exits non-zero -> log `ERROR`, continue remaining steps
 - Snapshot file missing on `-Rollback` -> log `ERROR`, exit with code 1
+
+## 7. Restore Model
+
+- Historical rollback:
+  - driven by snapshot data
+  - intended to return the machine to a recorded prior state
+- Profile-based restore:
+  - driven by predefined product-owned configuration targets
+  - intended to return the machine to a supported baseline or named profile
+- Modules may support one model or both, but docs and implementation must state which model is authoritative for each restore path.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1,4 +1,4 @@
-﻿# SPEC 鈥?Windows Config Automation Tool
+# SPEC - Windows Config Automation Tool
 
 **Date:** 2026-03-19
 
@@ -7,7 +7,7 @@
 ## 1. Script Interface
 
 ```
-winconf.ps1 [-DryRun] [-Verbose] [-Rollback] [-Module <name>]
+winconf.ps1 [-DryRun] [-Verbose] [-Rollback] [-RestoreProfile <name>] [-Module <name>]
 ```
 
 | Flag        | Type   | Description                                              |
@@ -15,13 +15,15 @@ winconf.ps1 [-DryRun] [-Verbose] [-Rollback] [-Module <name>]
 | `-DryRun`   | switch | Print what would change; make no writes                  |
 | `-Verbose`  | switch | Print each registry/service operation to console         |
 | `-Rollback` | switch | Restore values from snapshot history, then exit          |
+| `-RestoreProfile` | string | Restore to a predefined profile for a supported module |
 | `-Module`   | string | Run only the named module (e.g. `Power`, `ScreenLock`)   |
 
 Script interface policy:
 
 - `-Rollback` is the historical rollback mode backed by snapshot data.
-- The product may introduce a future profile-based restore mode that restores to predefined target configurations rather than to recorded historical state.
+- `-RestoreProfile <name>` is the predefined restore mode for supported modules.
 - Historical rollback and profile-based restore are distinct behaviors and must not be conflated.
+- `-Rollback` and `-RestoreProfile` must not be combined in the same invocation.
 
 ---
 
@@ -54,6 +56,7 @@ Set-RegValue -Path <string> -Name <string> -Value <object> -Type <RegistryValueK
   - build applicability bounds
   - unsupported-setting warning semantics
   - unauthorized-skip semantics for OS-protected optional settings
+  - predefined restore profile actions
 - Must log the registry path, value name, intended value, and prior value when available
 - Must distinguish these outcomes explicitly in logs and error handling:
   - missing registry key/value
@@ -61,6 +64,9 @@ Set-RegValue -Path <string> -Name <string> -Value <object> -Type <RegistryValueK
   - unsupported registry path/value for current OS
   - invalid registry definition
 - If a registry path is OS-specific or optional, the module must follow module-level policy for skip vs fail; it must not return an ambiguous generic error
+- Registry descriptor metadata may also define profile-based restore actions such as:
+  - set a predefined restore value
+  - remove a value during restore
 
 ### 2.3 Service.ps1
 
@@ -73,6 +79,14 @@ Stop-ServiceIfRunning  -Name <string> [-DryRun]
 - Calls `Save-Snapshot` before changing start type
 - Calls `Write-Log` on every operation
 - In `-DryRun` mode: logs intent, skips `sc.exe` calls
+
+Service restore compatibility policy:
+
+- Service-oriented modules are not yet fully covered by shared profile-based restore execution.
+- Future service restore metadata must distinguish at least:
+  - startup type target
+  - running/stopped target
+- `Privacy` is the current reference case showing why service restore needs both concepts rather than startup type alone.
 
 ### 2.4 Snapshot.ps1
 
@@ -103,50 +117,50 @@ Every module exposes one public function: `Invoke-<ModuleName> [-DryRun]`
 
 ### 3.1 Power.ps1
 
-| Setting              | Registry / Command                                                        | Value              |
-| -------------------- | ------------------------------------------------------------------------- | ------------------ |
-| High performance plan | `powercfg /setactive SCHEME_MIN`                                          | 鈥?                 |
-| Sleep timeout AC     | `powercfg /change standby-timeout-ac 0`                                   | 0 (never)          |
-| Sleep timeout DC     | `powercfg /change standby-timeout-dc 0`                                   | 0 (never)          |
-| Display timeout AC   | `powercfg /change monitor-timeout-ac 0`                                   | 0 (never)          |
-| Display timeout DC   | `powercfg /change monitor-timeout-dc 0`                                   | 0 (never)          |
-| Hibernate            | `powercfg /hibernate off`                                                 | 鈥?                 |
-| Fast startup         | `HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Power` `HiberbootEnabled` DWORD `0` | 0 |
+| Setting              | Registry / Command                                                        | Value              | Default |
+| -------------------- | ------------------------------------------------------------------------- | ------------------ | ------- |
+| High performance plan | `powercfg /setactive SCHEME_MIN`                                          | `N/A`              | Machine default active plan |
+| Sleep timeout AC     | `powercfg /change standby-timeout-ac 0`                                   | 0 (never)          | Machine default / OEM default |
+| Sleep timeout DC     | `powercfg /change standby-timeout-dc 0`                                   | 0 (never)          | Machine default / OEM default |
+| Display timeout AC   | `powercfg /change monitor-timeout-ac 0`                                   | 0 (never)          | Machine default / OEM default |
+| Display timeout DC   | `powercfg /change monitor-timeout-dc 0`                                   | 0 (never)          | Machine default / OEM default |
+| Hibernate            | `powercfg /hibernate off`                                                 | `N/A`              | Machine default |
+| Fast startup         | `HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Power` `HiberbootEnabled` DWORD `0` | 0 | Machine default (commonly `1`) |
 
 ### 3.2 ScreenLock.ps1
 
-| Setting              | Registry Path                                      | Name                    | Value | Type   |
-| -------------------- | -------------------------------------------------- | ----------------------- | ----- | ------ |
-| Screen saver enabled | `HKCU:\Control Panel\Desktop`                      | `ScreenSaveActive`      | `0`   | String |
-| Screen saver timeout | `HKCU:\Control Panel\Desktop`                      | `ScreenSaveTimeOut`     | `0`   | String |
-| Lock on resume       | `HKCU:\Control Panel\Desktop`                      | `ScreenSaverIsSecure`   | `0`   | String |
-| Idle lock (GPO)      | `HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System` | `InactivityTimeoutSecs` | `0` | DWORD |
+| Setting              | Registry Path                                      | Name                    | Value | Type   | Default |
+| -------------------- | -------------------------------------------------- | ----------------------- | ----- | ------ | ------- |
+| Screen saver enabled | `HKCU:\Control Panel\Desktop`                      | `ScreenSaveActive`      | `0`   | String | OS/user default |
+| Screen saver timeout | `HKCU:\Control Panel\Desktop`                      | `ScreenSaveTimeOut`     | `0`   | String | OS/user default |
+| Lock on resume       | `HKCU:\Control Panel\Desktop`                      | `ScreenSaverIsSecure`   | `0`   | String | OS/user default |
+| Idle lock (GPO)      | `HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System` | `InactivityTimeoutSecs` | `0` | DWORD | Absent / Not Configured |
 
 ### 3.3 WindowsUpdate.ps1
 
-| Setting                    | Registry Path                                                                 | Name                                    | Value | Type  |
-| -------------------------- | ----------------------------------------------------------------------------- | --------------------------------------- | ----- | ----- |
-| Disable auto update        | `HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU`                  | `NoAutoUpdate`                          | `1`   | DWORD |
-| Auto update mode           | `HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU`                  | `AUOptions`                             | `1`   | DWORD |
-| Hide update shutdown entry | `HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU`                  | `NoAUShutdownOption`                    | `1`   | DWORD |
-| Legacy shutdown fallback   | `HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU`                  | `NoAUAsDefaultShutdownOption`           | `1`   | DWORD |
-| Disable auto reboot prompt | `HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU`                  | `NoAutoRebootWithLoggedOnUsers`         | `1`   | DWORD |
-| Disable restart notification | `HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate`                  | `SetAutoRestartNotificationDisable`     | `1`   | DWORD |
-| Notification suppression   | `HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate`                     | `SetUpdateNotificationLevel`            | `2`   | DWORD |
-| Exclude update drivers     | `HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate`                     | `ExcludeWUDriversInQualityUpdate`       | `1`   | DWORD |
-| Block OS upgrade           | `HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate`                     | `DisableOSUpgrade`                      | `1`   | DWORD |
-| Preserve Microsoft Store   | `HKLM:\SOFTWARE\Policies\Microsoft\WindowsStore`                              | `RemoveWindowsStore`                    | `0`   | DWORD |
-| Store auto-download        | `HKLM:\SOFTWARE\Policies\Microsoft\WindowsStore`                              | `AutoDownload`                          | `4`   | DWORD |
-| Hide Windows Update page   | `HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer`           | `SettingsPageVisibility`                | `hide:windowsupdate-action` | String |
-| UX restart notifications   | `HKLM:\SOFTWARE\Microsoft\WindowsUpdate\UX\Settings`                          | `RestartNotificationsAllowed2`          | `0`   | DWORD |
-| Hide new update UX messages | `HKLM:\SOFTWARE\Microsoft\WindowsUpdate\UX\Settings`                         | `HideWUXMessages`                       | `1`   | DWORD |
-| PolicyManager auto update  | `HKLM:\SOFTWARE\Microsoft\PolicyManager\current\device\Update`                | `AllowAutoUpdate`                       | `0`   | DWORD |
-| PolicyManager notifications | `HKLM:\SOFTWARE\Microsoft\PolicyManager\current\device\Update`               | `DoNotShowUpdateNotifications`          | `1`   | DWORD |
-| PolicyManager power option | `HKLM:\SOFTWARE\Microsoft\PolicyManager\current\device\Update`                | `HideUpdatePowerOption`                 | `1`   | DWORD |
-| PolicyManager driver block | `HKLM:\SOFTWARE\Microsoft\PolicyManager\current\device\Update`                | `ExcludeWUDriversInQualityUpdate`       | `1`   | DWORD |
-| PolicyManager Store access | `HKLM:\SOFTWARE\Microsoft\PolicyManager\current\device\Store`                 | `AllowStore`                            | `1`   | DWORD |
-| PolicyManager Store download | `HKLM:\SOFTWARE\Microsoft\PolicyManager\current\device\Store`               | `AutoDownload`                          | `4`   | DWORD |
-| PolicyManager page visibility | `HKLM:\SOFTWARE\Microsoft\PolicyManager\current\device\Settings`           | `SettingsPageVisibility`                | `hide:windowsupdate-action` | String |
+| Setting                    | Registry Path                                                                 | Name                                    | Value | Type  | Default |
+| -------------------------- | ----------------------------------------------------------------------------- | --------------------------------------- | ----- | ----- | ------- |
+| Disable auto update        | `HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU`                  | `NoAutoUpdate`                          | `1`   | DWORD | Absent / Not Configured |
+| Auto update mode           | `HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU`                  | `AUOptions`                             | `1`   | DWORD | Absent / Not Configured |
+| Hide update shutdown entry | `HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU`                  | `NoAUShutdownOption`                    | `1`   | DWORD | Absent / Not Configured |
+| Legacy shutdown fallback   | `HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU`                  | `NoAUAsDefaultShutdownOption`           | `1`   | DWORD | Absent / Not Configured |
+| Disable auto reboot prompt | `HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU`                  | `NoAutoRebootWithLoggedOnUsers`         | `1`   | DWORD | Absent / Not Configured |
+| Disable restart notification | `HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate`                  | `SetAutoRestartNotificationDisable`     | `1`   | DWORD | Absent / Not Configured |
+| Notification suppression   | `HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate`                     | `SetUpdateNotificationLevel`            | `2`   | DWORD | Absent / Not Configured |
+| Exclude update drivers     | `HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate`                     | `ExcludeWUDriversInQualityUpdate`       | `1`   | DWORD | Absent / Not Configured |
+| Block OS upgrade           | `HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate`                     | `DisableOSUpgrade`                      | `1`   | DWORD | Absent / Not Configured |
+| Preserve Microsoft Store   | `HKLM:\SOFTWARE\Policies\Microsoft\WindowsStore`                              | `RemoveWindowsStore`                    | `0`   | DWORD | Absent / Not Configured |
+| Store auto-download        | `HKLM:\SOFTWARE\Policies\Microsoft\WindowsStore`                              | `AutoDownload`                          | `4`   | DWORD | Absent / Not Configured |
+| Hide Windows Update page   | `HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer`           | `SettingsPageVisibility`                | `hide:windowsupdate-action` | String | Absent / Not Configured |
+| UX restart notifications   | `HKLM:\SOFTWARE\Microsoft\WindowsUpdate\UX\Settings`                          | `RestartNotificationsAllowed2`          | `0`   | DWORD | Absent / Not Configured |
+| Hide new update UX messages | `HKLM:\SOFTWARE\Microsoft\WindowsUpdate\UX\Settings`                         | `HideWUXMessages`                       | `1`   | DWORD | Absent / Not Configured |
+| PolicyManager auto update  | `HKLM:\SOFTWARE\Microsoft\PolicyManager\current\device\Update`                | `AllowAutoUpdate`                       | `0`   | DWORD | Absent / Not Configured |
+| PolicyManager notifications | `HKLM:\SOFTWARE\Microsoft\PolicyManager\current\device\Update`               | `DoNotShowUpdateNotifications`          | `1`   | DWORD | Absent / Not Configured |
+| PolicyManager power option | `HKLM:\SOFTWARE\Microsoft\PolicyManager\current\device\Update`                | `HideUpdatePowerOption`                 | `1`   | DWORD | Absent / Not Configured |
+| PolicyManager driver block | `HKLM:\SOFTWARE\Microsoft\PolicyManager\current\device\Update`                | `ExcludeWUDriversInQualityUpdate`       | `1`   | DWORD | Absent / Not Configured |
+| PolicyManager Store access | `HKLM:\SOFTWARE\Microsoft\PolicyManager\current\device\Store`                 | `AllowStore`                            | `1`   | DWORD | Absent / Not Configured |
+| PolicyManager Store download | `HKLM:\SOFTWARE\Microsoft\PolicyManager\current\device\Store`               | `AutoDownload`                          | `4`   | DWORD | Absent / Not Configured |
+| PolicyManager page visibility | `HKLM:\SOFTWARE\Microsoft\PolicyManager\current\device\Settings`           | `SettingsPageVisibility`                | `hide:windowsupdate-action` | String | Absent / Not Configured |
 
 WindowsUpdate module policy:
 
@@ -159,13 +173,14 @@ WindowsUpdate module policy:
   - and `PolicyManager\current\device\*` keys where applicable.
 - Version-specific compatibility keys may be gated by OS build applicability, but the skip behavior must be explicit and logged.
 - The module must execute `gpupdate /force` after applying registry-backed policy changes unless a future implementation note explicitly defines a safe alternative.
+- `WindowsUpdate` must support a predefined restore profile named `Default` that removes the module-owned policy values to restore basic Windows Update behavior.
 
 ### 3.4 WindowsRestore.ps1
 
-| Setting                      | Command                | Value                          |
-| ---------------------------- | ---------------------- | ------------------------------ |
-| Disable restore availability | `reagentc /disable`    | Disable restore availability   |
-| Re-enable restore availability | `reagentc /enable`   | Re-enable restore availability |
+| Setting                      | Command                | Value                          | Default |
+| ---------------------------- | ---------------------- | ------------------------------ | ------- |
+| Disable restore availability | `reagentc /disable`    | Disable restore availability   | Machine default (commonly enabled) |
+| Re-enable restore availability | `reagentc /enable`   | Re-enable restore availability | Machine default (commonly enabled) |
 
 WindowsRestore module policy:
 
@@ -175,42 +190,44 @@ WindowsRestore module policy:
   - a disable path using `reagentc /disable`,
   - and a supported reverse path using `reagentc /enable`.
 - The supported reverse path is a dedicated `WindowsRestore` enable flow, not a Windows Update rollback side effect.
+- `WindowsRestore` must support a predefined restore profile named `Default` that maps to the enable path.
 - The module must log command execution clearly and distinguish normal execution from `-DryRun`.
 
 ### 3.5 Cortana.ps1
 
-| Setting              | Registry Path                                                                          | Name                        | Value | Type  |
-| -------------------- | -------------------------------------------------------------------------------------- | --------------------------- | ----- | ----- |
-| Disable Cortana      | `HKLM:\SOFTWARE\Policies\Microsoft\Windows\Windows Search`                             | `AllowCortana`              | `0`   | DWORD |
-| Disable web search   | `HKCU:\SOFTWARE\Policies\Microsoft\Windows\Explorer`                                   | `DisableSearchBoxSuggestions` | `1` | DWORD |
-| Hide taskbar button  | `HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced`                    | `ShowCortanaButton`         | `0`   | DWORD |
+| Setting              | Registry Path                                                                          | Name                        | Value | Type  | Default |
+| -------------------- | -------------------------------------------------------------------------------------- | --------------------------- | ----- | ----- | ------- |
+| Disable Cortana      | `HKLM:\SOFTWARE\Policies\Microsoft\Windows\Windows Search`                             | `AllowCortana`              | `0`   | DWORD | Absent / Not Configured |
+| Disable web search   | `HKCU:\SOFTWARE\Policies\Microsoft\Windows\Explorer`                                   | `DisableSearchBoxSuggestions` | `1` | DWORD | Absent / Not Configured |
+| Hide taskbar button  | `HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced`                    | `ShowCortanaButton`         | `0`   | DWORD | OS default / version-dependent |
 
 ### 3.6 Notifications.ps1
 
-| Setting                    | Registry Path                                                                              | Name                              | Value | Type  |
-| -------------------------- | ------------------------------------------------------------------------------------------ | --------------------------------- | ----- | ----- |
-| Disable Action Center      | `HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer`                                       | `DisableNotificationCenter`       | `1`   | DWORD |
-| Disable toast notifications | `HKCU:\SOFTWARE\Policies\Microsoft\Windows\CurrentVersion\PushNotifications`              | `NoToastApplicationNotification`  | `1`   | DWORD |
-| Disable lock screen notifs | `HKLM:\SOFTWARE\Policies\Microsoft\Windows\System`                                         | `DisableLockScreenAppNotifications` | `1` | DWORD |
+| Setting                    | Registry Path                                                                              | Name                              | Value | Type  | Default |
+| -------------------------- | ------------------------------------------------------------------------------------------ | --------------------------------- | ----- | ----- | ------- |
+| Disable Action Center      | `HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer`                                       | `DisableNotificationCenter`       | `1`   | DWORD | Absent / Not Configured |
+| Disable toast notifications | `HKCU:\SOFTWARE\Policies\Microsoft\Windows\CurrentVersion\PushNotifications`              | `NoToastApplicationNotification`  | `1`   | DWORD | Absent / Not Configured |
+| Disable lock screen notifs | `HKLM:\SOFTWARE\Policies\Microsoft\Windows\System`                                         | `DisableLockScreenAppNotifications` | `1` | DWORD | Absent / Not Configured |
 
 ### 3.7 Privacy.ps1
 
-| Setting              | Registry Path                                                                 | Name                    | Value | Type  |
-| -------------------- | ----------------------------------------------------------------------------- | ----------------------- | ----- | ----- |
-| Telemetry level      | `HKLM:\SOFTWARE\Policies\Microsoft\Windows\DataCollection`                    | `AllowTelemetry`        | `0`   | DWORD |
-| Activity history     | `HKLM:\SOFTWARE\Policies\Microsoft\Windows\System`                            | `PublishUserActivities` | `0`   | DWORD |
-| DiagTrack service    | Service `DiagTrack`                                                           | 鈥?                      | `Disabled` | 鈥?|
+| Setting              | Registry Path                                                                 | Name                    | Value | Type  | Default |
+| -------------------- | ----------------------------------------------------------------------------- | ----------------------- | ----- | ----- | ------- |
+| Telemetry level      | `HKLM:\SOFTWARE\Policies\Microsoft\Windows\DataCollection`                    | `AllowTelemetry`        | `0`   | DWORD | Absent / Not Configured |
+| Activity history     | `HKLM:\SOFTWARE\Policies\Microsoft\Windows\System`                            | `PublishUserActivities` | `0`   | DWORD | Absent / Not Configured |
+| DiagTrack upload history | `HKLM:\SOFTWARE\Policies\Microsoft\Windows\System`                        | `UploadUserActivities`  | `0`   | DWORD | Absent / Not Configured |
+| DiagTrack service    | Service `DiagTrack`                                                       | `N/A` | `Disabled` | `N/A` | Machine default |
 
 ### 3.8 UI.ps1
 
-| Setting              | Registry Path                                                                          | Name                        | Value | Type  |
-| -------------------- | -------------------------------------------------------------------------------------- | --------------------------- | ----- | ----- |
-| Hide Task View button | `HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced`                   | `ShowTaskViewButton`        | `0`   | DWORD |
-| Disable News/Interests (policy path) | `HKLM:\SOFTWARE\Policies\Microsoft\Windows\Windows Feeds`            | `EnableFeeds`               | `0`   | DWORD |
-| Disable News/Interests (user path, Windows-version dependent) | `HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Feeds` | `ShellFeedsTaskbarViewMode` | `2`   | DWORD |
-| Hide widgets / Chat-style taskbar entry (Windows-version dependent) | `HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced` | `TaskbarDa` | `0` | DWORD |
-| Hide Meet Now        | `HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer`                   | `HideMeetNow`               | `1`   | DWORD |
-| Disable edge gestures | `HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\ImmersiveShell`                     | `EdgeUI\DisabledEdgeSwipe`  | `1`   | DWORD |
+| Setting              | Registry Path                                                                          | Name                        | Value | Type  | Default |
+| -------------------- | -------------------------------------------------------------------------------------- | --------------------------- | ----- | ----- | ------- |
+| Hide Task View button | `HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced`                   | `ShowTaskViewButton`        | `0`   | DWORD | OS default / version-dependent |
+| Disable News/Interests (policy path) | `HKLM:\SOFTWARE\Policies\Microsoft\Windows\Windows Feeds`            | `EnableFeeds`               | `0`   | DWORD | Absent / Not Configured |
+| Disable News/Interests (user path, Windows-version dependent) | `HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Feeds` | `ShellFeedsTaskbarViewMode` | `2`   | DWORD | OS default / version-dependent |
+| Hide widgets / Chat-style taskbar entry (Windows-version dependent) | `HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced` | `TaskbarDa` | `0` | DWORD | OS default / version-dependent |
+| Hide Meet Now        | `HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer`                   | `HideMeetNow`               | `1`   | DWORD | OS default / version-dependent |
+| Disable edge gestures | `HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\ImmersiveShell`                     | `EdgeUI\DisabledEdgeSwipe`  | `1`   | DWORD | OS/user default |
 
 UI module policy:
 
@@ -222,7 +239,7 @@ UI module policy:
 
 ---
 
-## 4. Background Service 鈥?winconf-agent
+## 4. Background Service - winconf-agent
 
 | Property       | Value                                      |
 | -------------- | ------------------------------------------ |
@@ -266,4 +283,7 @@ On drift detection: write `WARN` log entry, re-invoke the affected `Set-RegValue
 - Profile-based restore:
   - driven by predefined product-owned configuration targets
   - intended to return the machine to a supported baseline or named profile
+- Current implemented predefined restore profiles:
+  - `WindowsUpdate` -> `Default`
+  - `WindowsRestore` -> `Default`
 - Modules may support one model or both, but docs and implementation must state which model is authoritative for each restore path.

--- a/docs/issues/ISSUE-006-profile-based-restore-and-rollback-governance.md
+++ b/docs/issues/ISSUE-006-profile-based-restore-and-rollback-governance.md
@@ -70,6 +70,12 @@ Profile-based restore must support service-oriented modules where desired restor
 - a specific running/stopped target state,
 - or both.
 
+Current audit outcome:
+
+- registry-driven modules are the best first fit for the shared profile model
+- command-driven modules can also fit when they have explicit reverse commands
+- service-driven modules need a richer abstraction than the current snapshot model because startup type and running state are separate concerns
+
 ## 4. Acceptance Criteria
 
 ### Functional
@@ -124,3 +130,10 @@ The product should treat:
 - profile-based restore as product-defined target-state recovery
 
 and standardize both through a shared governance model instead of leaving reversal behavior module-specific.
+
+The first implementation targets should be:
+
+- `WindowsUpdate` for registry-driven predefined restore
+- `WindowsRestore` for command-driven predefined restore
+
+while service-driven modules such as `Privacy` remain an audited next-step rather than part of the first implementation wave.

--- a/docs/issues/ISSUE-006-profile-based-restore-and-rollback-governance.md
+++ b/docs/issues/ISSUE-006-profile-based-restore-and-rollback-governance.md
@@ -1,0 +1,126 @@
+# Issue Analysis: Profile-Based Restore and Rollback Governance
+
+Source Review: Derived from rollback behavior analysis across `Snapshot.ps1`, `winconf.ps1`, and current module implementations
+
+## 1. Feature ID
+
+**WINCFG-RESTORE-006**
+
+WinConf must support two distinct restoration models through a shared abstraction:
+
+- snapshot-based rollback to a recorded historical machine state
+- profile-based restore to a predefined target configuration
+
+## 2. Clear Requirement
+
+The system shall not treat `-Rollback` as the only restoration mechanism.
+
+The product shall distinguish between:
+
+1. Snapshot rollback
+   - Restore the machine to the recorded state captured before WinConf changed a setting.
+   - This is machine-history-based behavior.
+
+2. Profile-based restore
+   - Restore the machine to a predefined product-owned configuration profile.
+   - This is target-state-based behavior.
+
+The system shall provide a shared abstraction so both models can coexist without each module inventing bespoke reverse logic.
+
+The feature shall satisfy all of the following requirements:
+
+1. Snapshot rollback must remain supported for settings whose original state was captured.
+2. Profile-based restore must be available for modules where restoring to a fixed target state is more useful than restoring to the historically captured state.
+3. The same module may support both models.
+4. Users must be able to choose whether they want:
+   - rollback to snapshot,
+   - or restore to a named profile.
+5. Metadata-driven modules must be able to express both:
+   - forward/apply behavior,
+   - and reverse/profile behavior,
+   through the same implementation model where feasible.
+
+## 3. System-Level Operations
+
+### Registry
+
+Profile-based restore must support registry-backed settings that need an explicit reverse target, for example:
+
+- write a value to a predefined restore-state value
+- remove a value during restore
+- restore a setting to product-defined default behavior
+
+This cannot always be derived from snapshot data, because snapshot may reflect a historically undesirable device state.
+
+### Command
+
+Profile-based restore must support command-driven modules and reverse actions, for example:
+
+- `reagentc /disable`
+- `reagentc /enable`
+- future `powercfg` restore flows
+
+These actions need an explicit profile-driven reverse contract, not only snapshot behavior.
+
+### Service
+
+Profile-based restore must support service-oriented modules where desired restore behavior may mean:
+
+- a specific startup type,
+- a specific running/stopped target state,
+- or both.
+
+## 4. Acceptance Criteria
+
+### Functional
+
+- The architecture distinguishes snapshot rollback from profile-based restore explicitly.
+- The user-facing invocation contract can choose between:
+  - historical rollback,
+  - and predefined profile restore.
+- At least one registry-heavy module and one command-driven module can be represented by the shared restore abstraction after implementation.
+
+### Governance
+
+- Shared metadata can express both apply-state and restore/profile-state semantics where appropriate.
+- Modules no longer need to invent one-off reverse logic when they fit the shared model.
+- Documentation clearly explains when snapshot is authoritative and when profile restore is authoritative.
+
+### Safety
+
+- No module is forced to pretend that a predefined restore profile is the same thing as the machine's original state.
+- Users can distinguish:
+  - "put this device back the way it was recorded"
+  - from
+  - "put this device into a supported baseline configuration"
+
+## 5. Risks
+
+- **Semantic confusion risk**: users may confuse snapshot rollback with predefined restore unless both are named and documented clearly.
+- **Abstraction risk**: trying to force all modules into a single reverse model may overfit registry modules and underfit command/service modules.
+- **Compatibility risk**: some settings may restore more safely by deleting values than by writing explicit values, so profile metadata must support more than one reverse action type.
+- **Historical-state risk**: snapshot data can legitimately preserve an already undesirable machine state, so it cannot be the only restoration strategy.
+- **Migration risk**: existing rollback code is snapshot-centric, so adding profile restore must avoid breaking current rollback expectations.
+
+## 6. Missing Information
+
+- Final user-facing parameter shape for choosing restore mode.
+- Whether profiles should be global, per module, or both.
+- Naming scheme for predefined profiles such as:
+  - `Default`
+  - `RestoreBasic`
+  - `Baseline`
+  - `Enabled`
+- Whether profile restore should support dry-run output identical in quality to current apply flows.
+- Whether profile restore should participate in snapshot capture when it writes new state.
+
+## Recommended Interpretation
+
+The correct next step is not to replace snapshot rollback, but to add a second restoration model.
+
+The product should treat:
+
+- snapshot rollback as historical-state recovery
+- profile-based restore as product-defined target-state recovery
+
+and standardize both through a shared governance model instead of leaving reversal behavior module-specific.

--- a/docs/tasks/task-profile-based-restore-governance.md
+++ b/docs/tasks/task-profile-based-restore-governance.md
@@ -8,6 +8,10 @@ Related Spec: [../SPEC.md](../SPEC.md)
 
 **TASK-RESTORE-PROFILE-1**
 
+## Progress
+
+- Completed: `TASK-RESTORE-PROFILE-1-01` to `TASK-RESTORE-PROFILE-1-08`
+
 ## Objective
 
 Introduce a shared restore-governance model so WinConf can support both:
@@ -46,7 +50,7 @@ Each task in this file must be:
 Define the distinction between snapshot rollback and profile-based restore
 
 **Status**  
-Pending
+Completed
 
 **Scope**
 
@@ -80,7 +84,7 @@ Pending
 Define a shared metadata shape for predefined restore profiles
 
 **Status**  
-Pending
+Completed
 
 **Scope**
 
@@ -117,7 +121,7 @@ Pending
 Define user-facing restore mode selection in `winconf.ps1`
 
 **Status**  
-Pending
+Completed
 
 **Scope**
 
@@ -154,7 +158,7 @@ Pending
 Prototype profile-based restore for a metadata-driven registry module
 
 **Status**  
-Pending
+Completed
 
 **Scope**
 
@@ -186,7 +190,7 @@ Pending
 Prototype profile-based restore for a command-driven module
 
 **Status**  
-Pending
+Completed
 
 **Scope**
 
@@ -220,7 +224,7 @@ Pending
 Audit service-driven modules for restore-profile compatibility
 
 **Status**  
-Pending
+Completed
 
 **Scope**
 
@@ -255,7 +259,7 @@ Pending
 Add regression tests for restore-governance behavior
 
 **Status**  
-Pending
+Completed
 
 **Scope**
 
@@ -290,7 +294,7 @@ Pending
 Align documentation with the dual restore model
 
 **Status**  
-Pending
+Completed
 
 **Scope**
 

--- a/docs/tasks/task-profile-based-restore-governance.md
+++ b/docs/tasks/task-profile-based-restore-governance.md
@@ -1,0 +1,338 @@
+# Task Plan: Profile-Based Restore Governance
+
+Source Review: Follow-up design step after rollback limitations were identified across registry, service, and command-driven modules  
+Related Issue Analysis: [../issues/ISSUE-006-profile-based-restore-and-rollback-governance.md](../issues/ISSUE-006-profile-based-restore-and-rollback-governance.md)  
+Related Spec: [../SPEC.md](../SPEC.md)
+
+## Task Plan ID
+
+**TASK-RESTORE-PROFILE-1**
+
+## Objective
+
+Introduce a shared restore-governance model so WinConf can support both:
+
+- snapshot-based historical rollback
+- profile-based predefined restore
+
+without forcing every module to implement reverse behavior ad hoc.
+
+## Why This Plan Exists
+
+Current rollback behavior is strongest for registry-only modules whose original state was captured in snapshot data.
+
+It is weaker or semantically incomplete for modules that are:
+
+- command-driven
+- service-driven
+- or better served by a predefined restore baseline than by the historically captured device state
+
+This plan creates a common path forward instead of solving reversal one module at a time.
+
+## Execution Rules
+
+Each task in this file must be:
+
+- executable
+- testable
+- independent
+- scoped to one restore-governance outcome
+
+## Atomic Tasks
+
+### TASK-RESTORE-PROFILE-1-01
+
+**Title**  
+Define the distinction between snapshot rollback and profile-based restore
+
+**Status**  
+Pending
+
+**Scope**
+
+- Document the difference between:
+  - historical rollback from snapshot
+  - predefined restore to a product-owned profile
+- Define when each model is the source of truth.
+- Ensure this distinction is reflected in implementation-facing docs and future CLI behavior.
+
+**Deliverable**
+
+- A clear contract exists for the two restoration models.
+
+**Test**
+
+- Review issue docs and SPEC to confirm they distinguish the two models without contradiction.
+
+**Dependency**
+
+- None.
+
+**Done Definition**
+
+- The project no longer treats all restore behavior as if it were equivalent to snapshot rollback.
+
+---
+
+### TASK-RESTORE-PROFILE-1-02
+
+**Title**  
+Define a shared metadata shape for predefined restore profiles
+
+**Status**  
+Pending
+
+**Scope**
+
+- Extend the descriptor/governance model conceptually so settings can express:
+  - apply-state behavior
+  - restore-profile behavior
+- Ensure the model can represent at least:
+  - set value
+  - remove value
+  - run reverse command
+  - restore service startup type / state
+
+**Deliverable**
+
+- A metadata shape exists for profile-based restore behavior.
+
+**Test**
+
+- Review real examples from registry, service, and command-driven modules and confirm the model can represent them.
+
+**Dependency**
+
+- `TASK-RESTORE-PROFILE-1-01`
+
+**Done Definition**
+
+- Profile-based restore can be described through shared metadata rather than only narrative documentation.
+
+---
+
+### TASK-RESTORE-PROFILE-1-03
+
+**Title**  
+Define user-facing restore mode selection in `winconf.ps1`
+
+**Status**  
+Pending
+
+**Scope**
+
+- Define how the top-level script chooses between:
+  - snapshot rollback
+  - profile-based restore
+- Decide whether profile restore is selected by:
+  - profile name
+  - mode flag
+  - or both.
+- Keep the interface explicit enough that users understand which restoration model they are invoking.
+
+**Deliverable**
+
+- A planned CLI contract exists for restore mode selection.
+
+**Test**
+
+- Review the proposed invocation patterns and confirm they distinguish historical rollback from predefined restore clearly.
+
+**Dependency**
+
+- `TASK-RESTORE-PROFILE-1-02`
+
+**Done Definition**
+
+- Future implementation work no longer needs to guess how users will invoke restore profiles.
+
+---
+
+### TASK-RESTORE-PROFILE-1-04
+
+**Title**  
+Prototype profile-based restore for a metadata-driven registry module
+
+**Status**  
+Pending
+
+**Scope**
+
+- Select one descriptor-driven registry-heavy module, such as `WindowsUpdate` or `UI`, as the first implementation target.
+- Define a fixed restore profile for that module.
+- Ensure the profile model can express all required reverse actions without relying on snapshot semantics.
+
+**Deliverable**
+
+- One registry-heavy module is mapped to the profile-based restore model.
+
+**Test**
+
+- Add or update tests that validate the module’s predefined restore profile contract.
+
+**Dependency**
+
+- `TASK-RESTORE-PROFILE-1-03`
+
+**Done Definition**
+
+- At least one registry-heavy module proves the shared restore profile abstraction works in practice.
+
+---
+
+### TASK-RESTORE-PROFILE-1-05
+
+**Title**  
+Prototype profile-based restore for a command-driven module
+
+**Status**  
+Pending
+
+**Scope**
+
+- Use `WindowsRestore` as the first command-driven target for profile-based restore governance.
+- Ensure the model can express both:
+  - apply/disable behavior
+  - restore/enable behavior
+- Confirm the design does not depend on snapshot semantics for command reversibility.
+
+**Deliverable**
+
+- One command-driven module proves the shared restore abstraction can handle non-registry actions.
+
+**Test**
+
+- Add or update tests that validate the command-driven restore profile contract.
+
+**Dependency**
+
+- `TASK-RESTORE-PROFILE-1-03`
+
+**Done Definition**
+
+- The shared restore model is proven beyond registry-only use cases.
+
+---
+
+### TASK-RESTORE-PROFILE-1-06
+
+**Title**  
+Audit service-driven modules for restore-profile compatibility
+
+**Status**  
+Pending
+
+**Scope**
+
+- Review modules such as `Privacy` for service-related reverse needs.
+- Determine whether service modules need metadata that distinguishes:
+  - startup type restore
+  - running/stopped state restore
+  - both
+- Record the decision in docs and implementation guidance.
+
+**Deliverable**
+
+- A service-restore compatibility decision exists for the shared profile model.
+
+**Test**
+
+- Review service-driven modules against the proposed metadata shape and document any gaps.
+
+**Dependency**
+
+- `TASK-RESTORE-PROFILE-1-02`
+
+**Done Definition**
+
+- Service modules are no longer an undefined corner case in the restore-governance design.
+
+---
+
+### TASK-RESTORE-PROFILE-1-07
+
+**Title**  
+Add regression tests for restore-governance behavior
+
+**Status**  
+Pending
+
+**Scope**
+
+- Add tests covering:
+  - snapshot rollback semantics
+  - predefined restore profile semantics
+  - correct user-facing mode distinction
+  - module-specific reverse behavior where implemented
+
+**Deliverable**
+
+- The restore-governance model is protected by automated tests.
+
+**Test**
+
+- Run the relevant rollback/restore-related test suites and verify all cases pass.
+
+**Dependency**
+
+- `TASK-RESTORE-PROFILE-1-04`
+- `TASK-RESTORE-PROFILE-1-05`
+
+**Done Definition**
+
+- Future regressions that blur or break the two restoration models are caught automatically.
+
+---
+
+### TASK-RESTORE-PROFILE-1-08
+
+**Title**  
+Align documentation with the dual restore model
+
+**Status**  
+Pending
+
+**Scope**
+
+- Update implementation-facing docs so they consistently describe:
+  - snapshot rollback
+  - profile-based restore
+  - module applicability
+  - user-facing restore mode selection
+- Ensure docs no longer imply snapshot is the only restoration strategy.
+
+**Deliverable**
+
+- Documentation reflects the final shared restore-governance design.
+
+**Test**
+
+- Review docs against code and planned CLI behavior for contradictions.
+
+**Dependency**
+
+- `TASK-RESTORE-PROFILE-1-07`
+
+**Done Definition**
+
+- Code, tests, and docs describe the same restore-governance model.
+
+## Suggested Execution Order
+
+1. `TASK-RESTORE-PROFILE-1-01`
+2. `TASK-RESTORE-PROFILE-1-02`
+3. `TASK-RESTORE-PROFILE-1-03`
+4. `TASK-RESTORE-PROFILE-1-04`
+5. `TASK-RESTORE-PROFILE-1-05`
+6. `TASK-RESTORE-PROFILE-1-06`
+7. `TASK-RESTORE-PROFILE-1-07`
+8. `TASK-RESTORE-PROFILE-1-08`
+
+## Completion Standard
+
+This plan is complete only when:
+
+- snapshot rollback and profile-based restore are both first-class concepts
+- at least one registry-heavy module and one command-driven module use the shared restore abstraction
+- restore mode selection is explicit at the top-level invocation layer
+- tests and docs protect the dual restore model from regression

--- a/scripts/lib/Registry.ps1
+++ b/scripts/lib/Registry.ps1
@@ -126,7 +126,8 @@ function New-RegSettingDescriptor {
         $MaxBuild = $null,
         [bool] $SkipOnUnauthorized = $false,
         [string] $UnsupportedWarningPrefix = 'Skipping unsupported optional setting',
-        [string] $WarningPrefix = 'Skipping optional setting'
+        [string] $WarningPrefix = 'Skipping optional setting',
+        [hashtable] $Profiles = @{}
     )
 
     return [PSCustomObject]@{
@@ -141,6 +142,22 @@ function New-RegSettingDescriptor {
         SkipOnUnauthorized       = $SkipOnUnauthorized
         UnsupportedWarningPrefix = $UnsupportedWarningPrefix
         WarningPrefix            = $WarningPrefix
+        Profiles                 = $Profiles
+    }
+}
+
+function New-RegProfileAction {
+    param(
+        [ValidateSet('set', 'remove')]
+        [string] $Action,
+        $Value = $null,
+        [Microsoft.Win32.RegistryValueKind] $Type = [Microsoft.Win32.RegistryValueKind]::DWord
+    )
+
+    return [PSCustomObject]@{
+        Action = $Action
+        Value  = $Value
+        Type   = $Type
     }
 }
 
@@ -162,6 +179,15 @@ function Test-RegSettingDescriptor {
     if ($Descriptor.Category -notin $validCategories) { return $false }
     if ($null -ne $Descriptor.MinBuild -and $Descriptor.MinBuild -isnot [int]) { return $false }
     if ($null -ne $Descriptor.MaxBuild -and $Descriptor.MaxBuild -isnot [int]) { return $false }
+    if ($null -eq $Descriptor.Profiles) { return $false }
+
+    foreach ($profileName in $Descriptor.Profiles.Keys) {
+        $profile = $Descriptor.Profiles[$profileName]
+        if ([string]::IsNullOrWhiteSpace([string]$profileName)) { return $false }
+        if ($null -eq $profile) { return $false }
+        if ($profile.Action -notin @('set', 'remove')) { return $false }
+        if ($profile.Action -eq 'set' -and -not (Test-RegDefinition -Path $Descriptor.Path -Name $Descriptor.Name -Value $profile.Value -Type $profile.Type)) { return $false }
+    }
 
     return $true
 }
@@ -227,6 +253,46 @@ function Set-RegValue {
     } catch {
         $category = Get-RegFailureCategory -Exception $_.Exception -Path $Path -Name $Name -Value $Value -Type $Type
         $message = New-RegFailureMessage -Category $category -Path $Path -Name $Name -IntendedValue $intendedDisplay -PriorValue $priorDisplay -Exception $_.Exception
+        Write-Log -Level ERROR -Module $Module -Message $message
+        throw [System.InvalidOperationException]::new($message, $_.Exception)
+    }
+}
+
+function Remove-RegValue {
+    param(
+        [string] $Path,
+        [string] $Name,
+        [string] $Module = 'Registry',
+        [switch] $DryRun
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Path) -or [string]::IsNullOrWhiteSpace($Name)) {
+        $message = "Registry remove failed (invalid registry definition): path='$Path' name='$Name'. Path and Name are required."
+        Write-Log -Level ERROR -Module $Module -Message $message
+        throw [System.InvalidOperationException]::new($message)
+    }
+
+    $current = Get-RegValue -Path $Path -Name $Name
+    $priorDisplay = Format-RegLogValue -Value $current
+
+    if ($DryRun) {
+        Write-Log -Level DRY -Module $Module -Message "Would remove path='$Path' name='$Name' prior='$priorDisplay'"
+        return
+    }
+
+    Save-Snapshot -Module $Module -Key "$Path\$Name" -CurrentValue $current
+
+    if (-not (Test-Path $Path) -or $null -eq $current) {
+        Write-Log -Level INFO -Module $Module -Message "Remove skipped path='$Path' name='$Name' prior='$priorDisplay'"
+        return
+    }
+
+    try {
+        Remove-ItemProperty -Path $Path -Name $Name -ErrorAction Stop
+        Write-Log -Level INFO -Module $Module -Message "Removed path='$Path' name='$Name' prior='$priorDisplay'"
+    } catch {
+        $category = Get-RegFailureCategory -Exception $_.Exception -Path $Path -Name $Name -Value 0 -Type ([Microsoft.Win32.RegistryValueKind]::DWord)
+        $message = "Registry remove failed ($category): path='$Path' name='$Name' prior='$priorDisplay'. $($_.Exception.Message)"
         Write-Log -Level ERROR -Module $Module -Message $message
         throw [System.InvalidOperationException]::new($message, $_.Exception)
     }
@@ -313,4 +379,36 @@ function Invoke-RegSettingDescriptor {
         -UnsupportedWarningPrefix $Descriptor.UnsupportedWarningPrefix `
         -WarningPrefix $Descriptor.WarningPrefix `
         -SkipOnUnauthorized:$Descriptor.SkipOnUnauthorized
+}
+
+function Invoke-RegSettingProfile {
+    param(
+        [Parameter(Mandatory)]
+        $Descriptor,
+        [Parameter(Mandatory)]
+        [string] $ProfileName,
+        [string] $Module = 'Registry',
+        [switch] $DryRun
+    )
+
+    if (-not (Test-RegSettingDescriptor -Descriptor $Descriptor)) {
+        $message = "Invalid registry setting descriptor for name='$($Descriptor.Name)' path='$($Descriptor.Path)'"
+        Write-Log -Level ERROR -Module $Module -Message $message
+        throw [System.InvalidOperationException]::new($message)
+    }
+
+    if (-not $Descriptor.Profiles.ContainsKey($ProfileName)) {
+        $message = "Restore profile '$ProfileName' is not defined for path='$($Descriptor.Path)' name='$($Descriptor.Name)'"
+        Write-Log -Level ERROR -Module $Module -Message $message
+        throw [System.InvalidOperationException]::new($message)
+    }
+
+    $profile = $Descriptor.Profiles[$ProfileName]
+
+    if ($profile.Action -eq 'remove') {
+        Remove-RegValue -Path $Descriptor.Path -Name $Descriptor.Name -Module $Module -DryRun:$DryRun
+        return
+    }
+
+    Set-RegValue -Path $Descriptor.Path -Name $Descriptor.Name -Value $profile.Value -Type $profile.Type -Module $Module -DryRun:$DryRun
 }

--- a/scripts/lib/Snapshot.ps1
+++ b/scripts/lib/Snapshot.ps1
@@ -58,20 +58,38 @@ function Remove-EmptyRegistryKey {
 }
 
 function Restore-Snapshot {
-    param([switch] $DryRun)
+    param(
+        [switch] $DryRun,
+        [string] $Module = ''
+    )
 
     if (-not (Test-Path $script:SnapshotFile)) {
         Write-Log -Level WARN -Module 'Rollback' -Message "No snapshot file found at $($script:SnapshotFile)"
         return
     }
 
-    $entries = @(Get-Content $script:SnapshotFile -Raw | ConvertFrom-Json)
-    [array]::Reverse($entries)
+    $rawEntries = Get-Content $script:SnapshotFile -Raw | ConvertFrom-Json
+    $entries = if ($rawEntries -is [System.Array]) { $rawEntries } elseif ($null -eq $rawEntries) { @() } else { @($rawEntries) }
+
+    if ($Module -ne '') {
+        $entries = @($entries | Where-Object { $_.Module -eq $Module })
+    }
+
+    $entries = @($entries)
+    if ($entries.Count -gt 1) {
+        [System.Array]::Reverse($entries)
+    }
 
     foreach ($entry in $entries) {
-        if ($entry.Key -like 'Service:*') {
-            $parts = $entry.Key -split ':'
-            $svcName   = $parts[1]
+        $entryKey = [string] $entry.Key
+
+        if ($entryKey -like 'Service:*') {
+            if ($entryKey -notmatch '^Service:(?<Name>[^:]+):StartType$') {
+                Write-Log -Level WARN -Module 'Rollback' -Message "Skipping invalid service snapshot entry key='$entryKey'"
+                continue
+            }
+
+            $svcName   = [string] $Matches.Name
             $startType = $entry.Value
             if ($DryRun) {
                 Write-Log -Level DRY -Module 'Rollback' -Message "Would restore service '$svcName' StartType=$startType"
@@ -80,10 +98,16 @@ function Restore-Snapshot {
                 Write-Log -Level INFO -Module 'Rollback' -Message "Restored service '$svcName' StartType=$startType"
             }
         } else {
-            $regPath = Split-Path $entry.Key -Parent
-            $regName = Split-Path $entry.Key -Leaf
+            $separatorIndex = $entryKey.LastIndexOf('\')
+            if ($separatorIndex -lt 0) {
+                Write-Log -Level WARN -Module 'Rollback' -Message "Skipping invalid registry snapshot entry key='$entryKey'"
+                continue
+            }
+
+            $regPath = [string] $entryKey.Substring(0, $separatorIndex)
+            $regName = [string] $entryKey.Substring($separatorIndex + 1)
             if ($DryRun) {
-                Write-Log -Level DRY -Module 'Rollback' -Message "Would restore $($entry.Key) = $($entry.Value)"
+                Write-Log -Level DRY -Module 'Rollback' -Message "Would restore $entryKey = $($entry.Value)"
             } else {
                 if ($null -eq $entry.Value) {
                     Remove-ItemProperty -Path $regPath -Name $regName -ErrorAction SilentlyContinue
@@ -92,7 +116,7 @@ function Restore-Snapshot {
                     New-Item -Path $regPath -Force -ErrorAction SilentlyContinue | Out-Null
                     New-ItemProperty -Path $regPath -Name $regName -Value $entry.Value -Force -ErrorAction SilentlyContinue | Out-Null
                 }
-                Write-Log -Level INFO -Module 'Rollback' -Message "Restored $($entry.Key) = $($entry.Value)"
+                Write-Log -Level INFO -Module 'Rollback' -Message "Restored $entryKey = $($entry.Value)"
             }
         }
     }

--- a/scripts/lib/Snapshot.ps1
+++ b/scripts/lib/Snapshot.ps1
@@ -57,6 +57,24 @@ function Remove-EmptyRegistryKey {
     }
 }
 
+function ConvertTo-SnapshotEntryList {
+    param($InputObject)
+
+    $list = [System.Collections.Generic.List[object]]::new()
+
+    if ($null -eq $InputObject) {
+        return $list
+    }
+
+    foreach ($item in @($InputObject)) {
+        if ($null -ne $item) {
+            $list.Add($item)
+        }
+    }
+
+    return $list
+}
+
 function Restore-Snapshot {
     param(
         [switch] $DryRun,
@@ -69,13 +87,12 @@ function Restore-Snapshot {
     }
 
     $rawEntries = Get-Content $script:SnapshotFile -Raw | ConvertFrom-Json
-    $entries = if ($rawEntries -is [System.Array]) { $rawEntries } elseif ($null -eq $rawEntries) { @() } else { @($rawEntries) }
+    $entries = ConvertTo-SnapshotEntryList -InputObject $rawEntries
 
     if ($Module -ne '') {
-        $entries = @($entries | Where-Object { $_.Module -eq $Module })
+        $entries = ConvertTo-SnapshotEntryList -InputObject ($entries | Where-Object { $_.Module -eq $Module })
     }
 
-    $entries = @($entries)
     if ($entries.Count -gt 1) {
         [System.Array]::Reverse($entries)
     }

--- a/scripts/lib/Snapshot.ps1
+++ b/scripts/lib/Snapshot.ps1
@@ -82,8 +82,9 @@ function Restore-Snapshot {
     )
 
     if (-not (Test-Path $script:SnapshotFile)) {
-        Write-Log -Level WARN -Module 'Rollback' -Message "No snapshot file found at $($script:SnapshotFile)"
-        return
+        $message = "No snapshot file found at $($script:SnapshotFile)"
+        Write-Log -Level ERROR -Module 'Rollback' -Message $message
+        throw [System.IO.FileNotFoundException]::new($message, $script:SnapshotFile)
     }
 
     $rawEntries = Get-Content $script:SnapshotFile -Raw | ConvertFrom-Json

--- a/scripts/lib/Snapshot.ps1
+++ b/scripts/lib/Snapshot.ps1
@@ -49,8 +49,8 @@ function Remove-EmptyRegistryKey {
     $item = Get-Item -Path $Path -ErrorAction SilentlyContinue
     if (-not $item) { return }
 
-    $hasSubKeys = ($item.GetSubKeyNames().Count -gt 0)
-    $propertyCount = ($item.Property | Where-Object { $_ -ne '(default)' }).Count
+    $hasSubKeys = (@($item.GetSubKeyNames()).Count -gt 0)
+    $propertyCount = @($item.Property | Where-Object { $_ -ne '(default)' }).Count
 
     if (-not $hasSubKeys -and $propertyCount -eq 0) {
         Remove-Item -Path $Path -Force -ErrorAction SilentlyContinue
@@ -63,7 +63,7 @@ function ConvertTo-SnapshotEntryList {
     $list = [System.Collections.Generic.List[object]]::new()
 
     if ($null -eq $InputObject) {
-        return $list
+        return (, $list)
     }
 
     foreach ($item in @($InputObject)) {
@@ -72,7 +72,7 @@ function ConvertTo-SnapshotEntryList {
         }
     }
 
-    return $list
+    return (, $list)
 }
 
 function Restore-Snapshot {

--- a/scripts/modules/WindowsRestore.ps1
+++ b/scripts/modules/WindowsRestore.ps1
@@ -76,14 +76,14 @@ function Invoke-WindowsRestoreEnable {
 function Invoke-WindowsRestore {
     param(
         [switch] $DryRun,
-        [switch] $Enable
+        [string] $RestoreProfile = ''
     )
 
     $module = 'WindowsRestore'
 
     Write-Log -Level INFO -Module $module -Message '=== Starting WindowsRestore module ==='
 
-    if ($Enable) {
+    if ($RestoreProfile -eq 'Default') {
         Invoke-WindowsRestoreEnable -DryRun:$DryRun
     } else {
         Invoke-WindowsRestoreDisable -DryRun:$DryRun

--- a/scripts/modules/WindowsUpdate.ps1
+++ b/scripts/modules/WindowsUpdate.ps1
@@ -16,27 +16,27 @@ function Get-WindowsUpdateSettings {
     $policyManagerSettings  = 'HKLM:\SOFTWARE\Microsoft\PolicyManager\current\device\Settings'
 
     return @(
-        (New-RegSettingDescriptor -Name 'NoAutoUpdate' -Path $auPath -Value 1 -Category 'required_policy_backed'),
-        (New-RegSettingDescriptor -Name 'AUOptions' -Path $auPath -Value 1 -Category 'required_policy_backed'),
-        (New-RegSettingDescriptor -Name 'NoAUShutdownOption' -Path $auPath -Value 1 -Category 'required_policy_backed'),
-        (New-RegSettingDescriptor -Name 'NoAUAsDefaultShutdownOption' -Path $auPath -Value 1 -Category 'required_policy_backed'),
-        (New-RegSettingDescriptor -Name 'NoAutoRebootWithLoggedOnUsers' -Path $auPath -Value 1 -Category 'required_policy_backed'),
-        (New-RegSettingDescriptor -Name 'SetAutoRestartNotificationDisable' -Path $wuPath -Value 1 -Category 'required_policy_backed'),
-        (New-RegSettingDescriptor -Name 'SetUpdateNotificationLevel' -Path $wuPath -Value 2 -Category 'required_policy_backed'),
-        (New-RegSettingDescriptor -Name 'ExcludeWUDriversInQualityUpdate' -Path $wuPath -Value 1 -Category 'required_policy_backed'),
-        (New-RegSettingDescriptor -Name 'DisableOSUpgrade' -Path $wuPath -Value 1 -Category 'required_policy_backed'),
-        (New-RegSettingDescriptor -Name 'RemoveWindowsStore' -Path $storePath -Value 0 -Category 'required_policy_backed'),
-        (New-RegSettingDescriptor -Name 'AutoDownload' -Path $storePath -Value 4 -Category 'required_policy_backed'),
-        (New-RegSettingDescriptor -Name 'SettingsPageVisibility' -Path $explorerPath -Value 'hide:windowsupdate-action' -Type String -Category 'required_policy_backed'),
-        (New-RegSettingDescriptor -Name 'RestartNotificationsAllowed2' -Path $uxPath -Value 0 -Category 'required_policy_backed'),
-        (New-RegSettingDescriptor -Name 'HideWUXMessages' -Path $uxPath -Value 1 -Category 'required_policy_backed'),
-        (New-RegSettingDescriptor -Name 'AllowAutoUpdate' -Path $policyManagerUpdate -Value 0 -Category 'required_policy_backed'),
-        (New-RegSettingDescriptor -Name 'DoNotShowUpdateNotifications' -Path $policyManagerUpdate -Value 1 -Category 'required_policy_backed'),
-        (New-RegSettingDescriptor -Name 'HideUpdatePowerOption' -Path $policyManagerUpdate -Value 1 -Category 'required_policy_backed'),
-        (New-RegSettingDescriptor -Name 'ExcludeWUDriversInQualityUpdate' -Path $policyManagerUpdate -Value 1 -Category 'required_policy_backed'),
-        (New-RegSettingDescriptor -Name 'AllowStore' -Path $policyManagerStore -Value 1 -Category 'required_policy_backed'),
-        (New-RegSettingDescriptor -Name 'AutoDownload' -Path $policyManagerStore -Value 4 -Category 'required_policy_backed'),
-        (New-RegSettingDescriptor -Name 'SettingsPageVisibility' -Path $policyManagerSettings -Value 'hide:windowsupdate-action' -Type String -Category 'required_policy_backed')
+        (New-RegSettingDescriptor -Name 'NoAutoUpdate' -Path $auPath -Value 1 -Category 'required_policy_backed' -Profiles @{ Default = (New-RegProfileAction -Action 'remove') }),
+        (New-RegSettingDescriptor -Name 'AUOptions' -Path $auPath -Value 1 -Category 'required_policy_backed' -Profiles @{ Default = (New-RegProfileAction -Action 'remove') }),
+        (New-RegSettingDescriptor -Name 'NoAUShutdownOption' -Path $auPath -Value 1 -Category 'required_policy_backed' -Profiles @{ Default = (New-RegProfileAction -Action 'remove') }),
+        (New-RegSettingDescriptor -Name 'NoAUAsDefaultShutdownOption' -Path $auPath -Value 1 -Category 'required_policy_backed' -Profiles @{ Default = (New-RegProfileAction -Action 'remove') }),
+        (New-RegSettingDescriptor -Name 'NoAutoRebootWithLoggedOnUsers' -Path $auPath -Value 1 -Category 'required_policy_backed' -Profiles @{ Default = (New-RegProfileAction -Action 'remove') }),
+        (New-RegSettingDescriptor -Name 'SetAutoRestartNotificationDisable' -Path $wuPath -Value 1 -Category 'required_policy_backed' -Profiles @{ Default = (New-RegProfileAction -Action 'remove') }),
+        (New-RegSettingDescriptor -Name 'SetUpdateNotificationLevel' -Path $wuPath -Value 2 -Category 'required_policy_backed' -Profiles @{ Default = (New-RegProfileAction -Action 'remove') }),
+        (New-RegSettingDescriptor -Name 'ExcludeWUDriversInQualityUpdate' -Path $wuPath -Value 1 -Category 'required_policy_backed' -Profiles @{ Default = (New-RegProfileAction -Action 'remove') }),
+        (New-RegSettingDescriptor -Name 'DisableOSUpgrade' -Path $wuPath -Value 1 -Category 'required_policy_backed' -Profiles @{ Default = (New-RegProfileAction -Action 'remove') }),
+        (New-RegSettingDescriptor -Name 'RemoveWindowsStore' -Path $storePath -Value 0 -Category 'required_policy_backed' -Profiles @{ Default = (New-RegProfileAction -Action 'remove') }),
+        (New-RegSettingDescriptor -Name 'AutoDownload' -Path $storePath -Value 4 -Category 'required_policy_backed' -Profiles @{ Default = (New-RegProfileAction -Action 'remove') }),
+        (New-RegSettingDescriptor -Name 'SettingsPageVisibility' -Path $explorerPath -Value 'hide:windowsupdate-action' -Type String -Category 'required_policy_backed' -Profiles @{ Default = (New-RegProfileAction -Action 'remove') }),
+        (New-RegSettingDescriptor -Name 'RestartNotificationsAllowed2' -Path $uxPath -Value 0 -Category 'required_policy_backed' -Profiles @{ Default = (New-RegProfileAction -Action 'remove') }),
+        (New-RegSettingDescriptor -Name 'HideWUXMessages' -Path $uxPath -Value 1 -Category 'required_policy_backed' -Profiles @{ Default = (New-RegProfileAction -Action 'remove') }),
+        (New-RegSettingDescriptor -Name 'AllowAutoUpdate' -Path $policyManagerUpdate -Value 0 -Category 'required_policy_backed' -Profiles @{ Default = (New-RegProfileAction -Action 'remove') }),
+        (New-RegSettingDescriptor -Name 'DoNotShowUpdateNotifications' -Path $policyManagerUpdate -Value 1 -Category 'required_policy_backed' -Profiles @{ Default = (New-RegProfileAction -Action 'remove') }),
+        (New-RegSettingDescriptor -Name 'HideUpdatePowerOption' -Path $policyManagerUpdate -Value 1 -Category 'required_policy_backed' -Profiles @{ Default = (New-RegProfileAction -Action 'remove') }),
+        (New-RegSettingDescriptor -Name 'ExcludeWUDriversInQualityUpdate' -Path $policyManagerUpdate -Value 1 -Category 'required_policy_backed' -Profiles @{ Default = (New-RegProfileAction -Action 'remove') }),
+        (New-RegSettingDescriptor -Name 'AllowStore' -Path $policyManagerStore -Value 1 -Category 'required_policy_backed' -Profiles @{ Default = (New-RegProfileAction -Action 'remove') }),
+        (New-RegSettingDescriptor -Name 'AutoDownload' -Path $policyManagerStore -Value 4 -Category 'required_policy_backed' -Profiles @{ Default = (New-RegProfileAction -Action 'remove') }),
+        (New-RegSettingDescriptor -Name 'SettingsPageVisibility' -Path $policyManagerSettings -Value 'hide:windowsupdate-action' -Type String -Category 'required_policy_backed' -Profiles @{ Default = (New-RegProfileAction -Action 'remove') })
     )
 }
 
@@ -64,7 +64,10 @@ function Invoke-WindowsUpdatePolicyRefresh {
 }
 
 function Invoke-WindowsUpdate {
-    param([switch] $DryRun)
+    param(
+        [switch] $DryRun,
+        [string] $RestoreProfile = ''
+    )
 
     $module = 'WindowsUpdate'
     $build  = Get-WindowsBuildNumber
@@ -72,7 +75,11 @@ function Invoke-WindowsUpdate {
     Write-Log -Level INFO -Module $module -Message '=== Starting WindowsUpdate module ==='
 
     foreach ($setting in Get-WindowsUpdateSettings) {
-        Invoke-RegSettingDescriptor -Descriptor $setting -Module $module -DryRun:$DryRun -Build $build
+        if ($RestoreProfile -ne '') {
+            Invoke-RegSettingProfile -Descriptor $setting -ProfileName $RestoreProfile -Module $module -DryRun:$DryRun
+        } else {
+            Invoke-RegSettingDescriptor -Descriptor $setting -Module $module -DryRun:$DryRun -Build $build
+        }
     }
 
     Invoke-WindowsUpdatePolicyRefresh -DryRun:$DryRun

--- a/scripts/winconf.ps1
+++ b/scripts/winconf.ps1
@@ -99,7 +99,7 @@ foreach ($m in $allModules) {
 }
 
 # ── Summary ───────────────────────────────────────────────────────────────────
-if ($failed.Count -gt 0) {
+if (@($failed).Count -gt 0) {
     Write-Log -Level WARN -Module MAIN -Message "Completed with errors in: $($failed -join ', ')"
     exit 1
 } else {

--- a/scripts/winconf.ps1
+++ b/scripts/winconf.ps1
@@ -36,7 +36,7 @@ Write-Log -Level INFO -Module MAIN -Message "winconf started (DryRun=$DryRun, Ro
 # ── Rollback branch ──────────────────────────────────────────────────────────
 if ($Rollback) {
     Write-Log -Level INFO -Module MAIN -Message "Rollback requested"
-    Restore-Snapshot -DryRun:$DryRun
+    Restore-Snapshot -DryRun:$DryRun -Module $Module
     Write-Log -Level INFO -Module MAIN -Message "Rollback complete"
     exit 0
 }

--- a/scripts/winconf.ps1
+++ b/scripts/winconf.ps1
@@ -9,6 +9,7 @@
 param(
     [switch] $DryRun,
     [switch] $Rollback,
+    [string] $RestoreProfile = "",
     [string] $Module = ""
 )
 
@@ -31,17 +32,6 @@ $scriptRoot   = $PSScriptRoot
 Initialize-Logger -LogPath $logFile -Verbose:($PSBoundParameters['Verbose'] -eq $true)
 Initialize-Snapshot -Path $snapshotFile
 
-Write-Log -Level INFO -Module MAIN -Message "winconf started (DryRun=$DryRun, Rollback=$Rollback, Module='$Module')"
-
-# ── Rollback branch ──────────────────────────────────────────────────────────
-if ($Rollback) {
-    Write-Log -Level INFO -Module MAIN -Message "Rollback requested"
-    Restore-Snapshot -DryRun:$DryRun -Module $Module
-    Write-Log -Level INFO -Module MAIN -Message "Rollback complete"
-    exit 0
-}
-
-# ── Load modules ─────────────────────────────────────────────────────────────
 $allModules = @(
     @{ Name = "Power";         File = "Power.ps1";         Fn = "Invoke-Power" },
     @{ Name = "ScreenLock";    File = "ScreenLock.ps1";    Fn = "Invoke-ScreenLock" },
@@ -53,6 +43,18 @@ $allModules = @(
     @{ Name = "UI";            File = "UI.ps1";            Fn = "Invoke-UI" }
 )
 
+Write-Log -Level INFO -Module MAIN -Message "winconf started (DryRun=$DryRun, Rollback=$Rollback, RestoreProfile='$RestoreProfile', Module='$Module')"
+
+if ($Rollback -and $RestoreProfile -ne "") {
+    Write-Log -Level ERROR -Module MAIN -Message "Cannot combine -Rollback with -RestoreProfile"
+    exit 1
+}
+
+if ($RestoreProfile -ne "" -and $Module -eq "") {
+    Write-Log -Level ERROR -Module MAIN -Message "Restore profile mode requires -Module"
+    exit 1
+}
+
 # Filter to requested module if specified
 if ($Module -ne "") {
     $selected = $allModules | Where-Object { $_.Name -eq $Module }
@@ -61,6 +63,19 @@ if ($Module -ne "") {
         exit 1
     }
     $allModules = @($selected)
+}
+
+if ($RestoreProfile -ne "" -and $Module -notin @('WindowsUpdate', 'WindowsRestore')) {
+    Write-Log -Level ERROR -Module MAIN -Message "Module '$Module' does not support restore profiles"
+    exit 1
+}
+
+# ── Rollback branch ──────────────────────────────────────────────────────────
+if ($Rollback) {
+    Write-Log -Level INFO -Module MAIN -Message "Rollback requested"
+    Restore-Snapshot -DryRun:$DryRun -Module $Module
+    Write-Log -Level INFO -Module MAIN -Message "Rollback complete"
+    exit 0
 }
 
 foreach ($m in $allModules) {
@@ -72,7 +87,11 @@ $failed = @()
 
 foreach ($m in $allModules) {
     try {
-        & $m.Fn -DryRun:$DryRun
+        if ($RestoreProfile -ne "") {
+            & $m.Fn -DryRun:$DryRun -RestoreProfile $RestoreProfile
+        } else {
+            & $m.Fn -DryRun:$DryRun
+        }
     } catch {
         Write-Log -Level ERROR -Module $m.Name -Message "Module failed: $_"
         $failed += $m.Name

--- a/scripts/winconf.ps1
+++ b/scripts/winconf.ps1
@@ -73,9 +73,14 @@ if ($RestoreProfile -ne "" -and $Module -notin @('WindowsUpdate', 'WindowsRestor
 # ── Rollback branch ──────────────────────────────────────────────────────────
 if ($Rollback) {
     Write-Log -Level INFO -Module MAIN -Message "Rollback requested"
-    Restore-Snapshot -DryRun:$DryRun -Module $Module
-    Write-Log -Level INFO -Module MAIN -Message "Rollback complete"
-    exit 0
+    try {
+        Restore-Snapshot -DryRun:$DryRun -Module $Module
+        Write-Log -Level INFO -Module MAIN -Message "Rollback complete"
+        exit 0
+    } catch {
+        Write-Log -Level ERROR -Module MAIN -Message "Rollback failed: $($_.Exception.Message)"
+        exit 1
+    }
 }
 
 foreach ($m in $allModules) {

--- a/tests/Registry.Descriptor.ps1.Tests.ps1
+++ b/tests/Registry.Descriptor.ps1.Tests.ps1
@@ -25,4 +25,17 @@ Describe 'Registry.ps1 descriptor-driven execution' {
         $descriptor.SkipOnUnauthorized | Should Be $true
         (Test-RegSettingApplicable -Descriptor $descriptor -Build 22631) | Should Be $true
     }
+
+    It 'represents a predefined restore profile for registry settings correctly' {
+        $descriptor = New-RegSettingDescriptor `
+            -Name 'NoAutoUpdate' `
+            -Path 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU' `
+            -Value 1 `
+            -Category 'required_policy_backed' `
+            -Profiles @{ Default = (New-RegProfileAction -Action 'remove') }
+
+        (Test-RegSettingDescriptor -Descriptor $descriptor) | Should Be $true
+        $descriptor.Profiles.ContainsKey('Default') | Should Be $true
+        $descriptor.Profiles.Default.Action | Should Be 'remove'
+    }
 }

--- a/tests/Registry.ps1.Tests.ps1
+++ b/tests/Registry.ps1.Tests.ps1
@@ -173,4 +173,23 @@ Describe 'Registry.ps1 Issue #1 behavior' {
 
         Test-Path $wuPath | Should Be $false
     }
+
+    It 'supports module-scoped rollback under strict mode when no snapshot entries match the requested module' {
+        @(
+            [PSCustomObject]@{
+                Module    = 'UI'
+                Key       = 'Service:wuauserv:StartType'
+                Value     = 'Manual'
+                Type      = 'Service'
+                Timestamp = '2026-03-24 09:05:00'
+            }
+        ) | ConvertTo-Json -Depth 5 | Set-Content -Path $script:SnapshotPath -Encoding UTF8
+
+        Set-StrictMode -Version Latest
+        try {
+            { Restore-Snapshot -Module 'WindowsUpdate' } | Should Not Throw
+        } finally {
+            Set-StrictMode -Off
+        }
+    }
 }

--- a/tests/Registry.ps1.Tests.ps1
+++ b/tests/Registry.ps1.Tests.ps1
@@ -129,4 +129,23 @@ Describe 'Registry.ps1 Issue #1 behavior' {
         { Restore-Snapshot -Module 'UI' } | Should Not Throw
         Test-Path $uiPath | Should Be $false
     }
+
+    It 'supports module-scoped rollback when only a single snapshot entry matches' {
+        $wuPath = Join-Path $script:BasePath ([guid]::NewGuid().ToString())
+        New-Item -Path $wuPath -Force | Out-Null
+        New-ItemProperty -Path $wuPath -Name 'UpdateValue' -Value 1 -PropertyType DWord -Force | Out-Null
+
+        @(
+            [PSCustomObject]@{
+                Module    = 'WindowsUpdate'
+                Key       = "$wuPath\UpdateValue"
+                Value     = $null
+                Type      = 'Registry'
+                Timestamp = '2026-03-23 11:30:00'
+            }
+        ) | ConvertTo-Json -Depth 5 | Set-Content -Path $script:SnapshotPath -Encoding UTF8
+
+        { Restore-Snapshot -Module 'WindowsUpdate' } | Should Not Throw
+        Test-Path $wuPath | Should Be $false
+    }
 }

--- a/tests/Registry.ps1.Tests.ps1
+++ b/tests/Registry.ps1.Tests.ps1
@@ -148,4 +148,29 @@ Describe 'Registry.ps1 Issue #1 behavior' {
         { Restore-Snapshot -Module 'WindowsUpdate' } | Should Not Throw
         Test-Path $wuPath | Should Be $false
     }
+
+    It 'supports module-scoped rollback under strict mode when only a single snapshot entry matches' {
+        $wuPath = Join-Path $script:BasePath ([guid]::NewGuid().ToString())
+        New-Item -Path $wuPath -Force | Out-Null
+        New-ItemProperty -Path $wuPath -Name 'UpdateValue' -Value 1 -PropertyType DWord -Force | Out-Null
+
+        @(
+            [PSCustomObject]@{
+                Module    = 'WindowsUpdate'
+                Key       = "$wuPath\UpdateValue"
+                Value     = $null
+                Type      = 'Registry'
+                Timestamp = '2026-03-24 09:00:00'
+            }
+        ) | ConvertTo-Json -Depth 5 | Set-Content -Path $script:SnapshotPath -Encoding UTF8
+
+        Set-StrictMode -Version Latest
+        try {
+            { Restore-Snapshot -Module 'WindowsUpdate' } | Should Not Throw
+        } finally {
+            Set-StrictMode -Off
+        }
+
+        Test-Path $wuPath | Should Be $false
+    }
 }

--- a/tests/Registry.ps1.Tests.ps1
+++ b/tests/Registry.ps1.Tests.ps1
@@ -192,4 +192,42 @@ Describe 'Registry.ps1 Issue #1 behavior' {
             Set-StrictMode -Off
         }
     }
+
+    It 'fails rollback when the snapshot file is missing' {
+        Remove-Item -Path $script:SnapshotPath -ErrorAction SilentlyContinue
+
+        $message = $null
+        try {
+            Restore-Snapshot -Module 'WindowsUpdate'
+        } catch {
+            $message = $_.Exception.Message
+        }
+
+        $message | Should BeLike 'No snapshot file found*'
+
+        $log = Get-Content $script:LogPath -Raw
+        $log | Should Match '\[Rollback\] \[ERROR\] No snapshot file found'
+    }
+
+    It 'supports module-scoped dry-run rollback for a single service snapshot entry under strict mode' {
+        @(
+            [PSCustomObject]@{
+                Module    = 'WindowsUpdate'
+                Key       = 'Service:wuauserv:StartType'
+                Value     = 'Manual'
+                Type      = 'Service'
+                Timestamp = '2026-03-24 09:10:00'
+            }
+        ) | ConvertTo-Json -Depth 5 | Set-Content -Path $script:SnapshotPath -Encoding UTF8
+
+        Set-StrictMode -Version Latest
+        try {
+            { Restore-Snapshot -Module 'WindowsUpdate' -DryRun } | Should Not Throw
+        } finally {
+            Set-StrictMode -Off
+        }
+
+        $log = Get-Content $script:LogPath -Raw
+        $log | Should BeLike '*Would restore service ''wuauserv'' StartType=Manual*'
+    }
 }

--- a/tests/Registry.ps1.Tests.ps1
+++ b/tests/Registry.ps1.Tests.ps1
@@ -103,4 +103,30 @@ Describe 'Registry.ps1 Issue #1 behavior' {
 
         Test-Path $script:KeyPath | Should Be $false
     }
+
+    It 'supports module-scoped rollback without touching unrelated snapshot entries' {
+        $uiPath = Join-Path $script:BasePath ([guid]::NewGuid().ToString())
+        New-Item -Path $uiPath -Force | Out-Null
+        New-ItemProperty -Path $uiPath -Name 'UiValue' -Value 1 -PropertyType DWord -Force | Out-Null
+
+        @(
+            [PSCustomObject]@{
+                Module    = 'WindowsUpdate'
+                Key       = 'Service:wuauserv:StartType'
+                Value     = 'Manual'
+                Type      = 'Service'
+                Timestamp = '2026-03-23 11:00:00'
+            }
+            [PSCustomObject]@{
+                Module    = 'UI'
+                Key       = "$uiPath\UiValue"
+                Value     = $null
+                Type      = 'Registry'
+                Timestamp = '2026-03-23 11:00:01'
+            }
+        ) | ConvertTo-Json -Depth 5 | Set-Content -Path $script:SnapshotPath -Encoding UTF8
+
+        { Restore-Snapshot -Module 'UI' } | Should Not Throw
+        Test-Path $uiPath | Should Be $false
+    }
 }

--- a/tests/Winconf.RestoreProfile.Tests.ps1
+++ b/tests/Winconf.RestoreProfile.Tests.ps1
@@ -15,4 +15,12 @@ Describe 'winconf.ps1 restore mode selection' {
         $content | Should Match 'does not support restore profiles'
         $content | Should Match 'RestoreProfile \$RestoreProfile'
     }
+
+    It 'fails rollback explicitly when snapshot restore fails' {
+        $content = Get-Content -Path "$PSScriptRoot\..\scripts\winconf.ps1" -Raw
+
+        $content | Should Match 'Rollback requested'
+        $content | Should Match 'Rollback failed:'
+        $content | Should Match 'exit 1'
+    }
 }

--- a/tests/Winconf.RestoreProfile.Tests.ps1
+++ b/tests/Winconf.RestoreProfile.Tests.ps1
@@ -1,0 +1,18 @@
+#Requires -Modules Pester
+
+Describe 'winconf.ps1 restore mode selection' {
+    It 'defines explicit restore profile selection separate from rollback' {
+        $content = Get-Content -Path "$PSScriptRoot\..\scripts\winconf.ps1" -Raw
+
+        $content | Should Match '\[string\] \$RestoreProfile = ""'
+        $content | Should Match 'Cannot combine -Rollback with -RestoreProfile'
+        $content | Should Match 'Restore profile mode requires -Module'
+    }
+
+    It 'limits profile-based restore to supported modules and passes the profile through' {
+        $content = Get-Content -Path "$PSScriptRoot\..\scripts\winconf.ps1" -Raw
+
+        $content | Should Match 'does not support restore profiles'
+        $content | Should Match 'RestoreProfile \$RestoreProfile'
+    }
+}

--- a/tests/WindowsRestore.ps1.Tests.ps1
+++ b/tests/WindowsRestore.ps1.Tests.ps1
@@ -10,8 +10,8 @@ Describe 'WindowsRestore.ps1 module alignment' {
         $content | Should Match 'Invoke-WindowsRestoreCommand -Command ''reagentc /disable'''
         $content | Should Match 'Invoke-WindowsRestoreCommand -Command ''reagentc /enable'''
         $content | Should Match 'function Invoke-WindowsRestore'
-        $content | Should Match '\[switch\] \$Enable'
-        $content | Should Match 'if \(\$Enable\) \{'
+        $content | Should Match '\[string\] \$RestoreProfile = '''''
+        $content | Should Match 'if \(\$RestoreProfile -eq ''Default''\) \{'
         $content | Should Match 'Invoke-WindowsRestoreEnable -DryRun:\$DryRun'
     }
 
@@ -39,6 +39,6 @@ Describe 'WindowsRestore.ps1 module alignment' {
 
         $restoreContent | Should Match 'function Invoke-WindowsRestoreEnable'
         $restoreContent | Should Match 'Skipping command=''reagentc /enable'' because restore availability is already enabled'
-        $mainContent | Should Not Match 'reagentc /enable'
+        $mainContent | Should Match '\[string\] \$RestoreProfile = ""'
     }
 }

--- a/tests/WindowsUpdate.ps1.Tests.ps1
+++ b/tests/WindowsUpdate.ps1.Tests.ps1
@@ -10,6 +10,7 @@ Describe 'WindowsUpdate.ps1 policy metadata alignment' {
         ($settings | Where-Object { $_.Name -eq 'NoAutoUpdate' -and $_.Path -match 'WindowsUpdate\\AU$' }).Category | Should Be 'required_policy_backed'
         ($settings | Where-Object { $_.Name -eq 'SettingsPageVisibility' -and $_.Path -match 'Policies\\Explorer$' }).Type | Should Be ([Microsoft.Win32.RegistryValueKind]::String)
         ($settings | Where-Object { $_.Name -eq 'AllowStore' -and $_.Path -match 'PolicyManager\\current\\device\\Store$' }).Value | Should Be 1
+        ($settings | Where-Object { $_.Name -eq 'NoAutoUpdate' -and $_.Path -match 'WindowsUpdate\\AU$' }).Profiles.Default.Action | Should Be 'remove'
     }
 
     It 'covers the full revised Windows Update policy contract' {
@@ -51,6 +52,7 @@ Describe 'WindowsUpdate.ps1 policy metadata alignment' {
         $content | Should Match 'New-RegSettingDescriptor -Name ''NoAutoUpdate'''
         $content | Should Match 'New-RegSettingDescriptor -Name ''SettingsPageVisibility'''
         $content | Should Match 'foreach \(\$setting in Get-WindowsUpdateSettings\)'
+        $content | Should Match 'Invoke-RegSettingProfile -Descriptor \$setting -ProfileName \$RestoreProfile -Module \$module -DryRun:\$DryRun'
         $content | Should Match 'Invoke-RegSettingDescriptor -Descriptor \$setting -Module \$module -DryRun:\$DryRun -Build \$build'
         $content | Should Match 'function Invoke-WindowsUpdatePolicyRefresh'
         $content | Should Match '& gpupdate /force \| Out-Null'


### PR DESCRIPTION
## Summary
- implement profile-based restore support for WindowsUpdate and WindowsRestore
- harden snapshot rollback handling for strict mode, empty results, and missing snapshot files
- add regression coverage for rollback and restore-profile scenarios

## Testing
- Invoke-Pester -Script tests/Registry.Descriptor.ps1.Tests.ps1
- Invoke-Pester -Script tests/WindowsUpdate.ps1.Tests.ps1
- Invoke-Pester -Script tests/WindowsRestore.ps1.Tests.ps1
- Invoke-Pester -Script tests/Winconf.RestoreProfile.Tests.ps1
- Invoke-Pester -Script tests/Registry.ps1.Tests.ps1